### PR TITLE
Use revolving memtables, not fixed blue/green

### DIFF
--- a/pkg/blobby/archive.go
+++ b/pkg/blobby/archive.go
@@ -142,7 +142,7 @@ func (b *Blobby) Flush(ctx context.Context) (*FlushStats, error) {
 	// TODO: check whether old sstable is still flushing
 	hPrev, hNext, err := b.mt.Swap(ctx)
 	if err != nil {
-		return stats, fmt.Errorf("switchMemtable: %s", err)
+		return stats, fmt.Errorf("memtable.Swap: %s", err)
 	}
 
 	stats.ActiveMemtable = hNext.Name()
@@ -187,10 +187,10 @@ func (b *Blobby) Flush(ctx context.Context) (*FlushStats, error) {
 	stats.BlobURL = dest
 	stats.Meta = meta
 
-	err = hPrev.Truncate(ctx)
+	err = b.mt.DropMemtable(ctx, hPrev.Name())
 	if err != nil {
 		// TODO: this is pretty bad. the sstable is readable, but we won't be able to swap back. what to do?
-		return stats, fmt.Errorf("handle.Truncate: %w", err)
+		return stats, fmt.Errorf("memtable.DropMemtable: %w", err)
 	}
 
 	return stats, nil

--- a/pkg/blobby/archive.go
+++ b/pkg/blobby/archive.go
@@ -140,7 +140,7 @@ func (b *Blobby) Flush(ctx context.Context) (*FlushStats, error) {
 	stats := &FlushStats{}
 
 	// TODO: check whether old sstable is still flushing
-	hPrev, hNext, err := b.mt.Swap(ctx)
+	hPrev, hNext, err := b.mt.Rotate(ctx)
 	if err != nil {
 		return stats, fmt.Errorf("memtable.Swap: %s", err)
 	}
@@ -187,10 +187,9 @@ func (b *Blobby) Flush(ctx context.Context) (*FlushStats, error) {
 	stats.BlobURL = dest
 	stats.Meta = meta
 
-	err = b.mt.DropMemtable(ctx, hPrev.Name())
+	err = b.mt.Drop(ctx, hPrev.Name())
 	if err != nil {
-		// TODO: this is pretty bad. the sstable is readable, but we won't be able to swap back. what to do?
-		return stats, fmt.Errorf("memtable.DropMemtable: %w", err)
+		return stats, fmt.Errorf("memtable.Drop: %w", err)
 	}
 
 	return stats, nil

--- a/pkg/blobby/archive_test.go
+++ b/pkg/blobby/archive_test.go
@@ -41,14 +41,14 @@ func TestBasicWriteRead(t *testing.T) {
 	// wrap blobby in test helper to make this readable
 	tb := &testBlobby{
 		ctx: ctx,
+		c:   c,
 		t:   t,
 		b:   b,
 	}
 
 	// -------------------------------------- part one: inserts and flushes ----
 
-	t1 := c.Now()
-	mt1 := fmt.Sprintf("mt_%d", t1.UTC().UnixNano())
+	t1 := tb.now()
 
 	// prepare n docs full of junk and write them all to the memtable. note that
 	// there's no overwriting, because each one has a unique key.
@@ -69,7 +69,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats := tb.get("001")
 	require.Equal(t, val, docs["001"])
 	require.Equal(t, &GetStats{
-		Source:         mt1,
+		Source:         t1.memtable,
 		BlobsFetched:   0,
 		RecordsScanned: 0,
 	}, gstats)
@@ -79,22 +79,21 @@ func TestBasicWriteRead(t *testing.T) {
 	require.Equal(t, val, docs["005"])
 
 	// flush memtable to the blobstore
-	t2 := c.Now()
-	mt2 := fmt.Sprintf("mt_%d", t2.UTC().UnixNano())
+	t2 := tb.now()
 	fstats, err := b.Flush(ctx)
 	require.NoError(t, err)
 	require.Equal(t, &FlushStats{
-		FlushedMemtable: mt1,
-		ActiveMemtable:  mt2,
-		BlobURL:         fmt.Sprintf("%d.sstable", t2.UnixMilli()),
+		FlushedMemtable: t1.memtable,
+		ActiveMemtable:  t2.memtable,
+		BlobURL:         t2.sstable,
 		Meta: &sstable.Meta{
 			MinKey:  "001",
 			MaxKey:  "010",
-			MinTime: t1.Add(15 * time.Millisecond),
-			MaxTime: t1.Add(15 * time.Millisecond * 10),
+			MinTime: t1.t.Add(15 * time.Millisecond),
+			MaxTime: t1.t.Add(15 * time.Millisecond * 10),
 			Count:   10,
 			Size:    497, // idk lol
-			Created: t2,
+			Created: t2.t,
 		},
 	}, fstats)
 
@@ -102,7 +101,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("001")
 	require.Equal(t, val, docs["001"])
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t2.UnixMilli()),
+		Source:         t2.sstable,
 		BlobsFetched:   1,
 		RecordsScanned: 1,
 	}, gstats)
@@ -126,7 +125,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("015")
 	require.Equal(t, val, docs["015"])
 	require.Equal(t, &GetStats{
-		Source: mt2,
+		Source: t2.memtable,
 	}, gstats)
 
 	// pass some time, so the second sstable will have a different URL. (they're
@@ -135,22 +134,21 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// flush again. note that the keys in this sstable are totally disjoint from
 	// the first.
-	t3 := c.Now()
-	mt3 := fmt.Sprintf("mt_%d", t3.UTC().UnixNano())
+	t3 := tb.now()
 	fstats, err = b.Flush(ctx)
 	require.NoError(t, err)
 	require.Equal(t, &FlushStats{
-		FlushedMemtable: mt2,
-		ActiveMemtable:  mt3,
-		BlobURL:         fmt.Sprintf("%d.sstable", t3.UnixMilli()),
+		FlushedMemtable: t2.memtable,
+		ActiveMemtable:  t3.memtable,
+		BlobURL:         t3.sstable,
 		Meta: &sstable.Meta{
 			MinKey:  "011",
 			MaxKey:  "020",
-			MinTime: t2.Add(15 * time.Millisecond),
-			MaxTime: t2.Add(15 * time.Millisecond * 10),
+			MinTime: t2.t.Add(15 * time.Millisecond),
+			MaxTime: t2.t.Add(15 * time.Millisecond * 10),
 			Count:   10,
 			Size:    497,
-			Created: t3,
+			Created: t3.t,
 		},
 	}, fstats)
 
@@ -159,14 +157,14 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("002")
 	require.Equal(t, val, docs["002"])
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t2.UnixMilli()),
+		Source:         t2.sstable,
 		BlobsFetched:   1,
 		RecordsScanned: 2,
 	}, gstats)
 	val, gstats = tb.get("014")
 	require.Equal(t, val, docs["014"])
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t3.UnixMilli()),
+		Source:         t3.sstable,
 		BlobsFetched:   1,
 		RecordsScanned: 4,
 	}, gstats)
@@ -188,32 +186,31 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("003")
 	require.Equal(t, val, []byte("xxx"))
 	require.Equal(t, &GetStats{
-		Source: mt3,
+		Source: t3.memtable,
 	}, gstats)
 	val, gstats = tb.get("013")
 	require.Equal(t, val, []byte("yyy"))
 	require.Equal(t, &GetStats{
-		Source: mt3,
+		Source: t3.memtable,
 	}, gstats)
 
 	// flush again. the two keys we just wrote will end up in the new sstable.
 	c.Advance(1 * time.Hour)
-	t4 := c.Now()
-	mt4 := fmt.Sprintf("mt_%d", t4.UTC().UnixNano())
+	t4 := tb.now()
 	fstats, err = b.Flush(ctx)
 	require.NoError(t, err)
 	require.Equal(t, &FlushStats{
-		FlushedMemtable: mt3,
-		ActiveMemtable:  mt4,
-		BlobURL:         fmt.Sprintf("%d.sstable", t4.UnixMilli()),
+		FlushedMemtable: t3.memtable,
+		ActiveMemtable:  t4.memtable,
+		BlobURL:         t4.sstable,
 		Meta: &sstable.Meta{
 			MinKey:  "003",
 			MaxKey:  "013",
-			MinTime: t3.Add(15 * time.Millisecond),
-			MaxTime: t3.Add(15 * time.Millisecond * 2),
+			MinTime: t3.t.Add(15 * time.Millisecond),
+			MaxTime: t3.t.Add(15 * time.Millisecond * 2),
 			Count:   2,
 			Size:    93,
-			Created: t4,
+			Created: t4.t,
 		},
 	}, fstats)
 
@@ -229,7 +226,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("003")
 	require.Equal(t, val, []byte("xxx"))
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t4.UnixMilli()),
+		Source:         t4.sstable,
 		BlobsFetched:   1, // <--
 		RecordsScanned: 1,
 	}, gstats)
@@ -239,7 +236,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("002")
 	require.Equal(t, val, docs["002"])
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t2.UnixMilli()),
+		Source:         t2.sstable,
 		BlobsFetched:   1, // <--
 		RecordsScanned: 2,
 	}, gstats)
@@ -255,7 +252,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("012")
 	require.Equal(t, val, docs["012"])
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t3.UnixMilli()),
+		Source:         t3.sstable,
 		BlobsFetched:   2, // <--
 		RecordsScanned: 4, // (003, 013), (011, 012)
 	}, gstats)
@@ -264,7 +261,7 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// perform a full compaction. every sstable merged into one.
 	c.Advance(1 * time.Hour)
-	t5 := c.Now()
+	t5 := tb.now()
 	cstats, err := b.Compact(ctx, CompactionOptions{})
 	require.NoError(t, err)
 	require.Len(t, cstats, 1)
@@ -273,11 +270,11 @@ func TestBasicWriteRead(t *testing.T) {
 		{
 			MinKey:  "001",
 			MaxKey:  "020",
-			MinTime: t1.Add(15 * time.Millisecond),
-			MaxTime: t3.Add(15 * time.Millisecond * 2),
+			MinTime: t1.t.Add(15 * time.Millisecond),
+			MaxTime: t3.t.Add(15 * time.Millisecond * 2),
 			Count:   22,
 			Size:    1073,
-			Created: t5,
+			Created: t5.t,
 		},
 	}, cstats[0].Outputs)
 
@@ -293,7 +290,7 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("003")
 	require.Equal(t, []byte("xxx"), val)
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t5.UnixMilli()),
+		Source:         t5.sstable,
 		BlobsFetched:   1,
 		RecordsScanned: 3,
 	}, gstats)
@@ -302,14 +299,14 @@ func TestBasicWriteRead(t *testing.T) {
 	val, gstats = tb.get("013")
 	require.Equal(t, []byte("yyy"), val)
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t5.UnixMilli()),
+		Source:         t5.sstable,
 		BlobsFetched:   1,
 		RecordsScanned: 14,
 	}, gstats)
 
 	// check that the old sstables were deleted.
-	for _, tt := range []time.Time{t2, t3, t4} {
-		_, _, err = b.bs.Find(ctx, fmt.Sprintf("%d.sstable", tt.UnixMilli()), "001")
+	for _, ts := range []instant{t2, t3, t4} {
+		_, _, err = b.bs.Find(ctx, ts.sstable, "001")
 		require.Error(t, err)
 	}
 
@@ -323,7 +320,7 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// flush to create second sstable
 	c.Advance(1 * time.Hour)
-	t6 := c.Now()
+	t6 := tb.now()
 	fstats, err = b.Flush(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, fstats.Meta.Count)
@@ -336,7 +333,7 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// flush to create third sstable
 	c.Advance(1 * time.Hour)
-	t7 := c.Now()
+	t7 := tb.now()
 	fstats, err = b.Flush(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, fstats.Meta.Count)
@@ -349,7 +346,7 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// flush to create fourth sstable
 	c.Advance(1 * time.Hour)
-	t8 := c.Now()
+	t8 := tb.now()
 	fstats, err = b.Flush(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, fstats.Meta.Count)
@@ -362,7 +359,7 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// compact only the two newest files together
 	c.Advance(1 * time.Hour)
-	t9 := c.Now()
+	t9 := tb.now()
 	cstats, err = b.Compact(ctx, CompactionOptions{
 		Order:    compactor.NewestFirst,
 		MaxFiles: 2,
@@ -373,39 +370,39 @@ func TestBasicWriteRead(t *testing.T) {
 
 	// verify only newest two files were inputs
 	require.Len(t, cstats[0].Inputs, 2)
-	require.Equal(t, t8.Unix(), cstats[0].Inputs[0].Created.Unix())
-	require.Equal(t, t7.Unix(), cstats[0].Inputs[1].Created.Unix())
+	require.Equal(t, t8.t.Unix(), cstats[0].Inputs[0].Created.Unix())
+	require.Equal(t, t7.t.Unix(), cstats[0].Inputs[1].Created.Unix())
 
 	// verify output metadata
 	require.Len(t, cstats[0].Outputs, 1)
 	require.Equal(t, &sstable.Meta{
 		MinKey:  "201",
 		MaxKey:  "302",
-		MinTime: t6.Add(15 * time.Millisecond * 1),
-		MaxTime: t7.Add(15 * time.Millisecond * 2),
+		MinTime: t6.t.Add(15 * time.Millisecond * 1),
+		MaxTime: t7.t.Add(15 * time.Millisecond * 2),
 		Count:   4,
 		Size:    175,
-		Created: t9,
+		Created: t9.t,
 	}, cstats[0].Outputs[0])
 
 	// verify we can read from the newly compacted file
 	val, gstats = tb.get("301")
 	require.Equal(t, []byte("c1"), val)
 	require.Equal(t, &GetStats{
-		Source:         fmt.Sprintf("%d.sstable", t9.Unix()),
+		Source:         t9.sstable,
 		BlobsFetched:   1,
 		RecordsScanned: 3,
 	}, gstats)
 
 	// verify the old uncompacted sstables still exist
-	_, _, err = b.bs.Find(ctx, fmt.Sprintf("%d.sstable", t5.Unix()), "001")
+	_, _, err = b.bs.Find(ctx, t5.sstable, "001")
 	require.NoError(t, err)
-	_, _, err = b.bs.Find(ctx, fmt.Sprintf("%d.sstable", t6.Unix()), "101")
+	_, _, err = b.bs.Find(ctx, t6.sstable, "101")
 	require.NoError(t, err)
 
 	// verify the compacted sstables were deleted
-	for _, tt := range []time.Time{t7, t8} {
-		_, _, err = b.bs.Find(ctx, fmt.Sprintf("%d.sstable", tt.Unix()), "001")
+	for _, ins := range []instant{t7, t8} {
+		_, _, err = b.bs.Find(ctx, ins.sstable, "001")
 		require.Error(t, err)
 	}
 
@@ -417,6 +414,7 @@ func TestBasicWriteRead(t *testing.T) {
 
 type testBlobby struct {
 	ctx context.Context
+	c   clockwork.Clock
 	t   *testing.T
 	b   *Blobby
 }
@@ -431,4 +429,23 @@ func (ta *testBlobby) get(key string) ([]byte, *GetStats) {
 	val, stats, err := ta.b.Get(ta.ctx, key)
 	require.NoError(ta.t, err)
 	return val, stats
+}
+
+type instant struct {
+	t        time.Time
+	memtable string
+	sstable  string
+}
+
+// now returns the current (fake) time, in a handy struct which also contains
+// the name of the memtable and sstable which would be created at that time.
+// this is just to avoid baking the filename patterns into the tests.
+func (ta *testBlobby) now() instant {
+	t := ta.c.Now()
+
+	return instant{
+		t:        t,
+		memtable: fmt.Sprintf("mt_%d", t.UTC().UnixNano()),
+		sstable:  fmt.Sprintf("%d.sstable", t.UnixMilli()),
+	}
 }

--- a/pkg/memtable/handle.go
+++ b/pkg/memtable/handle.go
@@ -37,9 +37,8 @@ func (h *Handle) Flush(ctx context.Context, ch chan *types.Record) error {
 
 	for cur.Next(ctx) {
 		var rec types.Record
-		var err error
 
-		err = cur.Decode(&rec)
+		err := cur.Decode(&rec)
 		if err != nil {
 			return fmt.Errorf("Decode: %w", err)
 		}
@@ -47,6 +46,7 @@ func (h *Handle) Flush(ctx context.Context, ch chan *types.Record) error {
 		ch <- &rec
 	}
 
+	// TODO: does this belong at the bottom?
 	close(ch)
 
 	err = cur.Err()
@@ -57,7 +57,6 @@ func (h *Handle) Flush(ctx context.Context, ch chan *types.Record) error {
 	return nil
 }
 
-// Create initializes the collection for this handle with appropriate indexes
 func (h *Handle) Create(ctx context.Context) error {
 	err := h.db.CreateCollection(ctx, h.coll.Name())
 	if err != nil {
@@ -80,18 +79,4 @@ func (h *Handle) Create(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// Count returns the number of documents in the collection
-func (h *Handle) Count(ctx context.Context) (int64, error) {
-	return h.coll.CountDocuments(ctx, bson.M{})
-}
-
-// IsEmpty returns true if the collection has no documents
-func (h *Handle) IsEmpty(ctx context.Context) (bool, error) {
-	count, err := h.Count(ctx)
-	if err != nil {
-		return false, err
-	}
-	return count == 0, nil
 }

--- a/pkg/memtable/handle.go
+++ b/pkg/memtable/handle.go
@@ -47,7 +47,6 @@ func (h *Handle) Flush(ctx context.Context, ch chan *types.Record) error {
 		ch <- &rec
 	}
 
-	// TODO: does this belong at the bottom?
 	close(ch)
 
 	err = cur.Err()
@@ -58,15 +57,7 @@ func (h *Handle) Flush(ctx context.Context, ch chan *types.Record) error {
 	return nil
 }
 
-func (h *Handle) Truncate(ctx context.Context) error {
-	err := h.coll.Drop(ctx)
-	if err != nil {
-		return fmt.Errorf("Drop: %w", err)
-	}
-
-	return h.Create(ctx)
-}
-
+// Create initializes the collection for this handle with appropriate indexes
 func (h *Handle) Create(ctx context.Context) error {
 	err := h.db.CreateCollection(ctx, h.coll.Name())
 	if err != nil {
@@ -89,4 +80,18 @@ func (h *Handle) Create(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Count returns the number of documents in the collection
+func (h *Handle) Count(ctx context.Context) (int64, error) {
+	return h.coll.CountDocuments(ctx, bson.M{})
+}
+
+// IsEmpty returns true if the collection has no documents
+func (h *Handle) IsEmpty(ctx context.Context) (bool, error) {
+	count, err := h.Count(ctx)
+	if err != nil {
+		return false, err
+	}
+	return count == 0, nil
 }

--- a/pkg/memtable/memtable_test.go
+++ b/pkg/memtable/memtable_test.go
@@ -38,7 +38,7 @@ func TestSwap(t *testing.T) {
 	c.Advance(1 * time.Second)
 
 	// Swap to create a new memtable
-	hOld, hNew, err := mt.Swap(ctx)
+	hOld, hNew, err := mt.Rotate(ctx)
 	require.NoError(t, err)
 	require.Equal(t, mtn1, hOld.Name())
 	require.NotEqual(t, mtn1, hNew.Name())
@@ -69,7 +69,7 @@ func TestSwap(t *testing.T) {
 	c.Advance(1 * time.Second)
 
 	// Drop the old memtable
-	err = mt.DropMemtable(ctx, mtn1)
+	err = mt.Drop(ctx, mtn1)
 	require.NoError(t, err)
 
 	// Verify k1 is no longer readable

--- a/pkg/memtable/memtable_test.go
+++ b/pkg/memtable/memtable_test.go
@@ -3,6 +3,7 @@ package memtable
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -24,46 +25,63 @@ func TestSwap(t *testing.T) {
 	err := mt.Init(ctx)
 	require.NoError(t, err)
 
-	// write to default table (blue)
+	// Get initial memtable name
+	mtn1, err := getCurrentMemtableName(ctx, t, mt)
+	require.NoError(t, err)
+
+	// Write to initial table
 	dest1, err := mt.Put(ctx, "k1", []byte("v1"))
 	require.NoError(t, err)
-	require.Equal(t, blueMemtableName, dest1)
+	require.Equal(t, mtn1, dest1)
 
-	// first swap: blue -> green
-	hNow, hPrev, err := mt.Swap(ctx)
+	// Advance the clock before swap to ensure unique timestamp
+	c.Advance(1 * time.Second)
+
+	// Swap to create a new memtable
+	hOld, hNew, err := mt.Swap(ctx)
 	require.NoError(t, err)
-	require.Equal(t, greenMemtableName, hPrev.Name())
+	require.Equal(t, mtn1, hOld.Name())
+	require.NotEqual(t, mtn1, hNew.Name())
+	require.True(t, strings.HasPrefix(hNew.Name(), "mt_"))
 
-	// write to now-active table (green)
+	// Verify the new memtable is now active
+	mtn2, err := getCurrentMemtableName(ctx, t, mt)
+	require.NoError(t, err)
+	require.Equal(t, hNew.Name(), mtn2)
+
+	// Write to now-active table
 	dest2, err := mt.Put(ctx, "k2", []byte("v2"))
 	require.NoError(t, err)
-	require.Equal(t, greenMemtableName, dest2)
+	require.Equal(t, mtn2, dest2)
 
-	// verify both writes can be read back
+	// Verify both writes can be read back
 	rec1, src1, err := mt.Get(ctx, "k1")
 	require.NoError(t, err)
 	require.Equal(t, []byte("v1"), rec1.Document)
-	require.Equal(t, dest1, src1)
+	require.Equal(t, mtn1, src1)
+
 	rec2, src2, err := mt.Get(ctx, "k2")
 	require.NoError(t, err)
 	require.Equal(t, []byte("v2"), rec2.Document)
-	require.Equal(t, dest2, src2)
+	require.Equal(t, mtn2, src2)
 
-	// try to swap back: green -> blue
-	// fails because we haven't truncated blue
-	_, _, err = mt.Swap(ctx)
-	require.EqualError(t, err, fmt.Sprintf("want to activate %s, but is not empty", blueMemtableName))
+	// Advance clock again before dropping
+	c.Advance(1 * time.Second)
 
-	// so truncate it, to drop all the data
-	// (note that we didn't flush, we're not testing that here.)
-	err = hNow.Truncate(ctx)
+	// Drop the old memtable
+	err = mt.DropMemtable(ctx, mtn1)
 	require.NoError(t, err)
 
-	// try to swap back again: green -> blue
-	// it works this time
-	_, hNow, err = mt.Swap(ctx)
+	// Verify k1 is no longer readable
+	_, _, err = mt.Get(ctx, "k1")
+	require.Error(t, err)
+	require.IsType(t, &NotFound{}, err)
+
+	// k2 should still be readable
+	rec2, src2, err = mt.Get(ctx, "k2")
 	require.NoError(t, err)
-	require.Equal(t, blueMemtableName, hNow.Name())
+	require.Equal(t, []byte("v2"), rec2.Document)
+	require.Equal(t, mtn2, src2)
 }
 
 func TestPut(t *testing.T) {
@@ -75,13 +93,17 @@ func TestPut(t *testing.T) {
 	err := mt.Init(ctx)
 	require.NoError(t, err)
 
-	// write to default table (blue)
+	// Get the current memtable name
+	currentName, err := getCurrentMemtableName(ctx, t, mt)
+	require.NoError(t, err)
+
+	// Write to current table
 	dest, err := mt.Put(ctx, "k", []byte("vvvv"))
 	require.NoError(t, err)
-	require.Equal(t, blueMemtableName, dest)
+	require.Equal(t, currentName, dest)
 
-	// check that it made it to mongo
-	recs := getRecords(ctx, t, mt, blueMemtableName, "k")
+	// Check that it made it to mongo
+	recs := getRecords(ctx, t, mt, currentName, "k")
 	require.Equal(t, []types.Record{
 		{
 			Key:       "k",
@@ -100,12 +122,16 @@ func TestPutConcurrent(t *testing.T) {
 	err := mt.Init(ctx)
 	require.NoError(t, err)
 
-	// normal uncontended put.
+	// Get the current memtable name
+	currentName, err := getCurrentMemtableName(ctx, t, mt)
+	require.NoError(t, err)
+
+	// Normal uncontended put
 	_, err = mt.Put(ctx, "k", []byte("1111"))
 	require.NoError(t, err)
 	t1 := c.Now()
 
-	// now attempt to write to the same key. this will fail, because the time
+	// Now attempt to write to the same key. this will fail, because the time
 	// (per the fake clock) is the same as the previous write. it will sleep
 	// then retry
 	var wg sync.WaitGroup
@@ -115,19 +141,19 @@ func TestPutConcurrent(t *testing.T) {
 		wg.Done()
 	}()
 
-	// block until Put is sleeping.
+	// Block until Put is sleeping
 	ctx2, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	require.NoError(t, c.BlockUntilContext(ctx2, 1), "mt.Put did not sleep")
 
-	// advance 1.2ms to exceed the maximum sleep time (with jitter).
+	// Advance 1.2ms to exceed the maximum sleep time (with jitter)
 	c.Advance(retrySleep + retryJitter + 1)
 	t2 := c.Now()
 	wg.Wait()
 	require.NoError(t, err)
 
-	// check that both writes made it to mongo.
-	recs := getRecords(ctx, t, mt, blueMemtableName, "k")
+	// Check that both writes made it to mongo
+	recs := getRecords(ctx, t, mt, currentName, "k")
 	require.Equal(t, []types.Record{
 		{
 			Key:       "k",
@@ -140,6 +166,31 @@ func TestPutConcurrent(t *testing.T) {
 			Document:  []byte("2222"),
 		},
 	}, recs)
+}
+
+// Helper function to get the current memtable name
+func getCurrentMemtableName(ctx context.Context, t *testing.T, mt *Memtable) (string, error) {
+	db, err := mt.GetMongo(ctx)
+	require.NoError(t, err)
+
+	res := db.Collection(metaCollectionName).FindOne(ctx, bson.M{"_id": metaActiveMemtableDocID})
+	var doc bson.M
+	err = res.Decode(&doc)
+	if err != nil {
+		return "", err
+	}
+
+	val, ok := doc["value"]
+	if !ok {
+		return "", fmt.Errorf("no value key in active memtable doc")
+	}
+
+	s, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("value in active memtable doc was not string")
+	}
+
+	return s, nil
 }
 
 func getRecords(ctx context.Context, t *testing.T, mt *Memtable, coll string, key string) []types.Record {


### PR DESCRIPTION
this refactors things to use n memtables rather than always using n==2. rather than swapping between two memtables, we rotate by creating a new memtable, flushing the oldest one to the blobstore, and deleting it. not sure why i went with the blue/green approach in the first place.